### PR TITLE
Bug Fix: Condition should be still editable/deletable/both after editing

### DIFF
--- a/vaadin-simple-grid-filter/src/main/java/software/xdev/vaadin/FilterComponent.java
+++ b/vaadin-simple-grid-filter/src/main/java/software/xdev/vaadin/FilterComponent.java
@@ -344,11 +344,13 @@ public class FilterComponent<T> extends Composite<VerticalLayout> implements Bef
 		final boolean deletable;
 		final boolean editable;
 		
-		// Check if it's an initial condition
-		if(this.editingBadgeId != null && !this.editingBadgeId.equals(NO_BADGE_ID_STRING))
+		if(this.deletingBadgeEnabled != null && this.editingBadgeEnabled != null)
 		{
 			deletable = this.deletingBadgeEnabled;
 			editable = this.editingBadgeEnabled;
+			
+			this.deletingBadgeEnabled = null;
+			this.editingBadgeEnabled = null;
 		}
 		else
 		{
@@ -426,13 +428,14 @@ public class FilterComponent<T> extends Composite<VerticalLayout> implements Bef
 					// Make the cancel button invisible
 					this.btnCancelFilter.setVisible(false);
 					
-					// Just activated when the url parameters are activated
+					// Needed to save state of the condition if it was editable/deletable before editing
+					this.editingBadgeEnabled = badge.isBtnEditEnabled();
+					this.deletingBadgeEnabled = badge.isBtnDeleteEnabled();
+					
+					// Just activated when the url parameters are enabled
 					if(!this.identifier.isBlank())
 					{
 						this.editingBadgeId = badge.getBadgeId();
-						// Needed for the acceptFilterBtn
-						this.editingBadgeEnabled = badge.isBtnEditEnabled();
-						this.deletingBadgeEnabled = badge.isBtnDeleteEnabled();
 					}
 					
 					// Remove filter, update grid

--- a/vaadin-simple-grid-filter/src/main/java/software/xdev/vaadin/FilterComponent.java
+++ b/vaadin-simple-grid-filter/src/main/java/software/xdev/vaadin/FilterComponent.java
@@ -377,7 +377,7 @@ public class FilterComponent<T> extends Composite<VerticalLayout> implements Bef
 			this.deletingBadgeEnabled = null;
 			this.editingBadgeEnabled = null;
 			
-			if(this.editingBadgeEnabled != null)
+			if(this.editingBadgeId != null)
 			{
 				// Get customization rating from initial condition
 				customizationDegree = this.initialChipBadges

--- a/vaadin-simple-grid-filter/src/main/java/software/xdev/vaadin/FilterComponent.java
+++ b/vaadin-simple-grid-filter/src/main/java/software/xdev/vaadin/FilterComponent.java
@@ -374,13 +374,19 @@ public class FilterComponent<T> extends Composite<VerticalLayout> implements Bef
 			deletable = this.deletingBadgeEnabled;
 			editable = this.editingBadgeEnabled;
 			
-			// Get customization rating from initial condition
-			customizationDegree = this.initialChipBadges
-				.stream()
-				.filter(e -> e.getBadgeId().equals(this.editingBadgeId))
-				.toList()
-				.get(0)
-				.getCustomizationRating();
+			this.deletingBadgeEnabled = null;
+			this.editingBadgeEnabled = null;
+			
+			if(this.editingBadgeEnabled != null)
+			{
+				// Get customization rating from initial condition
+				customizationDegree = this.initialChipBadges
+					.stream()
+					.filter(e -> e.getBadgeId().equals(this.editingBadgeId))
+					.toList()
+					.get(0)
+					.getCustomizationRating();
+			}
 		}
 		else
 		{
@@ -468,11 +474,7 @@ public class FilterComponent<T> extends Composite<VerticalLayout> implements Bef
 					// Set the customization rating for the filter select and condition select
 					this.setUsedCustomizationDegreeForComponents(customizationDegree);
 					
-					// Just activated when the url parameters are activated
-					if(!this.identifier.isBlank())
-					{
-						this.editingBadgeId = badge.getBadgeId();
-					}
+					this.editingBadgeId = badge.getBadgeId();
 					
 					// Remove filter, update grid
 					this.removeChipBadgeCondition(badge);


### PR DESCRIPTION
Steps to reproduce:
1. Disable url parameter for the filter component
2. Edit a condition
4. Accept the edited condition
5. The initial condition is not editable anymore. Instead it's just deletable.

Expected behaviour:
The condition should still be editable/deletable/both after editing. This behavior is already fixed when the url parameters are enabled (if they would work).